### PR TITLE
added url redirect from steemit

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -62,10 +62,12 @@ export class RoutesLeft extends Component {
           <Route path="/hall-of-fame" exact component={Home} />
           <Route path="/hall-of-fame/@:author/:permlink" exact component={Post} />
           <Route path="/@:author/:permlink" exact component={Post} />
+          <Route path="/steemhunt/@:author/:permlink" exact render={(p) => (<Redirect to={`/@${p.match.params.author}/${p.match.params.permlink}`}/>)}/>
           <Route path="/@:author/:permlink/edit" exact component={Draft} />
           <Route path="/author/@:author" exact component={Profile} />
           <Route path="/author/@:author/:permlink" exact component={Post} />
-          <Route path="/wallet" exact component={Airdrop} />
+          <Route path="/@:author" exact render={(p) => (<Redirect to={`/author/@${p.match.params.author}`} />)} />
+          <Route path="/wallet" exact componet={Airdrop} />
           <Route path='*' component={NotFound} />
         </Switch>
       </div>


### PR DESCRIPTION
Just a small enhancement

If a user coming from steemit website, they presumably will just change steemit.com to steemhunt.com

`https://steemit.com/steemhunt/@superoo7/oh-my-zsh-making-terminal-pretty-again` to `https://steemhunt.com/steemhunt/@superoo7/oh-my-zsh-making-terminal-pretty-again`

and

`https://steemit.com/@superoo7` to 
`https://steemhunt.com/@superoo7`

with redirect, it redirect the first one to `/@superoo7/oh-my-zsh-making-terminal-pretty-again` and second one to `/author/@superoo7`

But this will lead to NotFound page.

To solve this, I created redirect for both post links and profile links.

I am not sure whether to create a new function in a new file or just directly make a line there in the Router.js