### PR TITLE
css formating for h1-h6 markdown

### DIFF
--- a/src/styles/features/_post.scss
+++ b/src/styles/features/_post.scss
@@ -581,27 +581,19 @@
       }
 
       h1 {
-        font-size: 20px;
+        font-size: 1.25rem;
       }
 
       h2 {
-        font-size: 18px;
+        font-size: 1.11rem;
       }
 
       h3 {
-        font-size: 16px;
+        font-size: 1.0rem;
       }
 
-      h4 {
-        font-size: 15px;
-      }
-
-      h5 {
-        font-size: 14px;
-      }
-
-      h6 {
-        font-size: 13px;
+      h4, h5, h6 {
+        font-size: 0.875rem;
       }
 
       @include responsive(mobile) {

--- a/src/styles/features/_post.scss
+++ b/src/styles/features/_post.scss
@@ -580,6 +580,30 @@
         color: $text_grey;
       }
 
+      h1 {
+        font-size: 20px;
+      }
+
+      h2 {
+        font-size: 18px;
+      }
+
+      h3 {
+        font-size: 16px;
+      }
+
+      h4 {
+        font-size: 15px;
+      }
+
+      h5 {
+        font-size: 14px;
+      }
+
+      h6 {
+        font-size: 13px;
+      }
+
       @include responsive(mobile) {
         border-left: 0;
         padding: 0 5px;


### PR DESCRIPTION
Previous setting: (Extracted from chrome dev tools)
```
h1: 20px
h2: 18px
h3: 16px
h4: 0.875rem
h5: 16px
h6: 16px
```

![image](https://user-images.githubusercontent.com/15358452/41983492-d1a46726-7a60-11e8-9dc5-3af6e1decf70.png)


This commit standardise it based on the previous:
```
h1: 20px
h2: 18px
h3: 16px
h4: 15px
h5: 14px
h6: 13px
```

![image](https://user-images.githubusercontent.com/15358452/41983503-d7f97238-7a60-11e8-990e-4a284ea38fa3.png)

