### PR TITLE
#252 - Lazyload images / ISSUE: Scroll lags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13382,6 +13382,11 @@
         "prop-types": "^15.5.8"
       }
     },
+    "react-lazyload": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-lazyload/-/react-lazyload-2.3.0.tgz",
+      "integrity": "sha512-0z3qmL+qtSERdfKFpn0yKXm+1Gg1ZLZBXnCzHhSGiu1L8iDARuCkbOypxEx9+ETxZvMnXj98xvWCs5jyXTuM2w=="
+    },
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-dom": "^16.4.1",
     "react-helmet": "^5.2.0",
     "react-icons": "^2.2.7",
+    "react-lazyload": "^2.3.0",
     "react-loadable": "^4.0.5",
     "react-markdown": "^2.5.1",
     "react-redux": "^5.0.7",

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -7,6 +7,7 @@ import queryString from 'query-string';
 import asyncComponent from 'asyncComponent';
 import { Icon } from 'antd';
 import isEmpty from 'lodash/isEmpty';
+import { forceCheck } from 'react-lazyload';
 import { getMeBegin, refreshMeBegin } from 'features/User/actions/getMe';
 import { selectMe } from 'features/User/selectors';
 import { selectSearchTerm } from 'features/Post/selectors';
@@ -109,6 +110,14 @@ class Right extends Component {
     clearInterval(this.refresher);
   }
 
+  handleScroll = (e) => {
+    // Check on every 300px difference - for better performence
+    if (!window.lastScrollTop || Math.abs(window.lastScrollTop - e.target.scrollTop) > 300) {
+      window.lastScrollTop = e.target.scrollTop;
+      forceCheck();
+    }
+  };
+
   render() {
     const List = isEmpty(this.props.searchTerm) ? HuntedList : Search;
     const AuthorList = isEmpty(this.props.searchTerm) ? HuntedListByAuthor : Search;
@@ -122,7 +131,7 @@ class Right extends Component {
     }
 
     return (
-      <div className="panel-right">
+      <div className="panel-right" onScroll={this.handleScroll}>
         {redirectPath && <Redirect to={redirectPath} /> /* Authentication redirection */ }
         <Header path={this.props.location.pathname}/>
         <Switch>

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -7,7 +7,6 @@ import queryString from 'query-string';
 import asyncComponent from 'asyncComponent';
 import { Icon } from 'antd';
 import isEmpty from 'lodash/isEmpty';
-import { forceCheck } from 'react-lazyload';
 import { getMeBegin, refreshMeBegin } from 'features/User/actions/getMe';
 import { selectMe } from 'features/User/selectors';
 import { selectSearchTerm } from 'features/Post/selectors';
@@ -110,14 +109,6 @@ class Right extends Component {
     clearInterval(this.refresher);
   }
 
-  handleScroll = (e) => {
-    // Check on every 300px difference - for better performence
-    if (!window.lastScrollTop || Math.abs(window.lastScrollTop - e.target.scrollTop) > 300) {
-      window.lastScrollTop = e.target.scrollTop;
-      forceCheck();
-    }
-  };
-
   render() {
     const List = isEmpty(this.props.searchTerm) ? HuntedList : Search;
     const AuthorList = isEmpty(this.props.searchTerm) ? HuntedListByAuthor : Search;
@@ -131,7 +122,7 @@ class Right extends Component {
     }
 
     return (
-      <div className="panel-right" onScroll={this.handleScroll}>
+      <div className="panel-right">
         {redirectPath && <Redirect to={redirectPath} /> /* Authentication redirection */ }
         <Header path={this.props.location.pathname}/>
         <Switch>

--- a/src/features/Post/components/PostItem.js
+++ b/src/features/Post/components/PostItem.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { Link } from 'react-router-dom';
 import { Icon } from 'antd';
+import LazyLoad from 'react-lazyload';
 import { selectMe } from 'features/User/selectors';
 import { getPostPath, getCachedImage } from '../utils';
 import { isModerator } from 'features/User/utils';
@@ -25,7 +26,9 @@ class PostItem extends Component {
       <div className={`post${rank === 1 ? ' top-border' : ''}${post.is_active ? '' : ' faded'}`}>
         <div className="rank">{rank}</div>
         <Link to={getPostPath(post, pathPrefix)}>
-          <img src={post.images && getCachedImage(post.images[0].link, 240, 240)} alt={post.title} className="thumbnail"/>
+          <LazyLoad height={0} offset={500} once={true} scroll={false}>
+            <img src={post.images && getCachedImage(post.images[0].link, 240, 240)} alt={post.title} className="thumbnail"/>
+          </LazyLoad>
         </Link>
         <div className="summary">
           <div className="title">

--- a/src/features/Post/components/PostItem.js
+++ b/src/features/Post/components/PostItem.js
@@ -26,7 +26,7 @@ class PostItem extends Component {
       <div className={`post${rank === 1 ? ' top-border' : ''}${post.is_active ? '' : ' faded'}`}>
         <div className="rank">{rank}</div>
         <Link to={getPostPath(post, pathPrefix)}>
-          <LazyLoad height={0} offset={500} once={true} scroll={false}>
+          <LazyLoad height={0} offset={500} once={true} scroll={false} overflow={true}>
             <img src={post.images && getCachedImage(post.images[0].link, 240, 240)} alt={post.title} className="thumbnail"/>
           </LazyLoad>
         </Link>

--- a/src/styles/_common.scss
+++ b/src/styles/_common.scss
@@ -151,7 +151,7 @@ hr {
     width: 50%;
     height: 100%;
     float: left;
-    overflow-x: hidden;
+    overflow-x: auto;
     overflow-y: scroll;
     -webkit-overflow-scrolling: touch;
     -ms-overflow-style: -ms-autohiding-scrollbar;


### PR DESCRIPTION
I just quickly implemented image lazyload for

1. Saving data transfer for users & for our server
2. Faster loading (especially good for pre-renderer fail)

However, this update makes scroll very laggy because it checks all images' positions on scroll events. I made it only fires every 300px of scroll, but it seem it still blocks scrolling quite a lot.

Is there any idea for improving the scroll performance?