### PR TITLE
Remove steemconnect login scope

### DIFF
--- a/src/utils/steemConnectAPI.js
+++ b/src/utils/steemConnectAPI.js
@@ -5,7 +5,7 @@ const api = sc2.Initialize({
   app: 'steemhunt.com',
   callbackURL: process.env.REACT_APP_STEEMCONNECT_REDIRECT_URL,
   accessToken: 'access_token',
-  scope: [ 'login', 'vote', 'comment', 'delete_comment', 'comment_options', 'custom_json' ],
+  scope: [ 'vote', 'comment', 'delete_comment', 'comment_options', 'custom_json' ],
 });
 
 export default api;


### PR DESCRIPTION
I've removed the login scope from the steemconnect init method. The login scope should be used only if none of the posting scope are used.